### PR TITLE
Disable processing of editable files

### DIFF
--- a/openreferee_server/defaults.py
+++ b/openreferee_server/defaults.py
@@ -83,3 +83,4 @@ CUSTOM_ACTIONS = [
     },
     {"name": "approve-qa", "title": "Approve QA", "color": "teal", "icon": "check"},
 ]
+PROCESS_EDITABLE_FILES = False

--- a/openreferee_server/schemas.py
+++ b/openreferee_server/schemas.py
@@ -134,6 +134,10 @@ class CreateEditableSchema(Schema):
     user = fields.Nested(UserSchema, required=True)
 
 
+class CreateEditableResponseSchema(Schema):
+    ready_for_review = fields.Boolean(load_default=False)
+
+
 class ReviewEditableSchema(Schema):
     action = fields.String(required=True)
     revision = fields.Nested(TransientRevisionSchema, unknown=EXCLUDE, required=True)


### PR DESCRIPTION
This PR adds a flag to disable "auto-distilling" of PDF files when submitting for editing (as requested [here](https://github.com/orgs/indico/projects/2/views/4?pane=issue&itemId=13023016)).
Alternatively the code for PDF processing could be entirely removed, but for now it's probably wiser to leave it as is.