### PR TITLE
Make Fail QA reset the editable state

### DIFF
--- a/openreferee_server/operations.py
+++ b/openreferee_server/operations.py
@@ -210,8 +210,8 @@ def process_custom_action(event, revision, action, user, endpoints):
             "comments": [{"internal": True, "text": "This revision has passed QA."}],
         }
     elif action == "fail-qa":
-        response = session.delete(
-            endpoints["revisions"]["undo"],
+        response = session.post(
+            endpoints["revisions"]["reset"],
         )
         response.raise_for_status()
         return {

--- a/openreferee_server/schemas.py
+++ b/openreferee_server/schemas.py
@@ -25,6 +25,7 @@ class EditableEndpointsSchema(Schema):
             "details": fields.String(required=True),
             "replace": fields.String(required=True),
             "undo": fields.String(required=True),
+            "reset": fields.String(required=True),
         }
     )
     file_upload = fields.String(required=True)

--- a/specs/openreferee.yaml
+++ b/specs/openreferee.yaml
@@ -467,12 +467,15 @@ components:
           type: string
         undo:
           type: string
+        reset:
+          type: string
         details:
           type: string
       required:
       - details
       - replace
       - undo
+      - reset
     EditableEndpoints:
       type: object
       properties:


### PR DESCRIPTION
This PR makes the Fail QA action reset the editable state, instead of simply undoing the last revision.