### PR TITLE
Show QA actions on changes_acceptance

### DIFF
--- a/openreferee_server/operations.py
+++ b/openreferee_server/operations.py
@@ -178,7 +178,7 @@ def process_accepted_revision(event, revision):
 def _can_access_action(revision, action, user):
     if not any(x["code"] in ACTION_ROLES for x in user["roles"]):
         return False
-    if revision["type"]["name"] == "acceptance":
+    if revision["type"]["name"] in {'acceptance', 'changes_acceptance'}:
         if any(t["code"] == Tag.QA_PENDING for t in revision["tags"]):
             return action in ("approve-qa", "fail-qa")
         return action == "fail-qa"

--- a/openreferee_server/server.py
+++ b/openreferee_server/server.py
@@ -285,7 +285,7 @@ def review_editable(
         "A new revision %r was submitted for contribution %r", revision_id, contrib_id
     )
     resp = {}
-    if action == "accept":
+    if action in {'accept', 'update_accept'}:
         resp = process_accepted_revision(event, revision)
 
     return ReviewResponseSchema().dump(resp), 201


### PR DESCRIPTION
This PR fixes a bug in which `changes_acceptance` revisions (`needs_submitter_confirmation`s that were accepted by the submitter) don't get the QA buttons.