### PR TITLE
Add notification for third party services

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ FLASK_ENV=development
 FLASK_DEBUG=1
 FLASK_APP=openreferee_server.app
 DATABASE_URI = 'postgresql:///openreferee'
+NOTIFY_URL=
+NOTIFY_TOKEN=

--- a/openreferee_server/app.py
+++ b/openreferee_server/app.py
@@ -5,7 +5,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
 from flask import Flask, jsonify
 from werkzeug.exceptions import HTTPException, UnprocessableEntity
-
+from .notify import NotifyExtension
 from . import __version__
 from .db import db, register_db_cli
 
@@ -26,6 +26,7 @@ def create_app():
     register_error_handlers(app)
     db.init_app(app)
     register_db_cli(app)
+    NotifyExtension(app, os.environ.get('NOTIFY_URL'), os.environ.get('NOTIFY_TOKEN'))
     app.register_blueprint(api)
     return app
 

--- a/openreferee_server/app.py
+++ b/openreferee_server/app.py
@@ -26,7 +26,7 @@ def create_app():
     register_error_handlers(app)
     db.init_app(app)
     register_db_cli(app)
-    notify_init(app, os.environ.get('NOTIFY_URL'), os.environ.get('NOTIFY_TOKEN'))
+    notify_init(app)
     app.register_blueprint(api)
     return app
 

--- a/openreferee_server/app.py
+++ b/openreferee_server/app.py
@@ -5,9 +5,10 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
 from flask import Flask, jsonify
 from werkzeug.exceptions import HTTPException, UnprocessableEntity
-from .notify import notify_init
+
 from . import __version__
 from .db import db, register_db_cli
+from .notify import notify_init
 
 try:
     from flask_cors import CORS

--- a/openreferee_server/app.py
+++ b/openreferee_server/app.py
@@ -5,7 +5,7 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
 from flask import Flask, jsonify
 from werkzeug.exceptions import HTTPException, UnprocessableEntity
-from .notify import NotifyExtension
+from .notify import notify_init
 from . import __version__
 from .db import db, register_db_cli
 
@@ -26,7 +26,7 @@ def create_app():
     register_error_handlers(app)
     db.init_app(app)
     register_db_cli(app)
-    NotifyExtension(app, os.environ.get('NOTIFY_URL'), os.environ.get('NOTIFY_TOKEN'))
+    notify_init(app, os.environ.get('NOTIFY_URL'), os.environ.get('NOTIFY_TOKEN'))
     app.register_blueprint(api)
     return app
 

--- a/openreferee_server/notify.py
+++ b/openreferee_server/notify.py
@@ -1,0 +1,45 @@
+import json
+import threading
+
+from .operations import setup_requests_session
+
+
+class NotifyService:
+    def __init__(self, url=None, token=None) -> None:
+        self.url = url
+        self.token = token
+        self.session = None
+
+    def send(self, payload):
+        try:
+            self.session.get(self.url, data=json.dumps({"payload": payload}))
+        except Exception:
+            pass
+
+    def notify(self, payload):
+        if self.url is None:
+            return
+
+        if self.session is None:
+            self.session = setup_requests_session(self.token)
+
+        threading.Thread(target=self.send, args=(payload,)).start()
+
+
+class NotifyExtension:
+    def __init__(self, context=None, notify_url=None, notify_token=None):
+        self.url = notify_url
+        self.token = notify_token
+        self.service = None
+        if context is not None:
+            self.init_app(context)
+
+    def init_app(self, context):
+        context.config.setdefault('NOTIFY_URL', self.url)
+        context.config.setdefault('NOTIFY_TOKEN', self.token)
+
+        self.service = NotifyService(context.config['NOTIFY_URL'], context.config['NOTIFY_TOKEN'])
+        if not hasattr(context, 'extensions'):
+            context.extensions = {}
+
+        context.extensions['notifier'] = self.service

--- a/openreferee_server/notify.py
+++ b/openreferee_server/notify.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import threading
 from requests.exceptions import HTTPError, ConnectionError, Timeout, RequestException
 from .operations import setup_requests_session
@@ -38,9 +39,9 @@ class NotifyService:
         threading.Thread(target=self.send, args=(payload,)).start()
 
 
-def notify_init(app, url, token):
-    app.config.setdefault('NOTIFY_URL', url)
-    app.config.setdefault('NOTIFY_TOKEN', token)
+def notify_init(app):
+    app.config.setdefault('NOTIFY_URL', os.environ.get('NOTIFY_URL'))
+    app.config.setdefault('NOTIFY_TOKEN', os.environ.get('NOTIFY_TOKEN'))
 
     if app.config['NOTIFY_URL'] not in [None, '']:
         app.logger.info("Enabling notifications to URL %s", app.config['NOTIFY_URL'])

--- a/openreferee_server/server.py
+++ b/openreferee_server/server.py
@@ -44,8 +44,8 @@ from .schemas import (
 )
 
 
-def notify(context, payload):
-    service = context.extensions.get('notifier')
+def notify(app, payload):
+    service = app.extensions.get('notifier')
     if service is not None:
         service.notify(payload)
 

--- a/openreferee_server/server.py
+++ b/openreferee_server/server.py
@@ -252,6 +252,15 @@ def create_editable(
         t.daemon = True
         t.start()
 
+    notify(current_app, {
+        "event": event.identifier,
+        "contrib_id": contrib_id,
+        "action": "create",
+        "editable_type": editable_type,
+        "user": user,
+        "request": request.json
+    })
+
     replace_revision_files()
     return CreateEditableResponseSchema().dump(resp), 201
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()


### PR DESCRIPTION
This will allow downstream systems to be notified when revisions are created in indico specifically for JACoW

It is fire and forget to prevent any outage affecting indico uptime.

The hope is that will enable a downstream system "e.g." catscan to perform a scan on a change, rather than polling.

Also first python PR ever, so I welcome any feedback.

If you are happy to merge and deploy the change, we can discuss the URL / Token on slack