### PR TITLE
Use the new reset flag on Fail QA

### DIFF
--- a/openreferee_server/defaults.py
+++ b/openreferee_server/defaults.py
@@ -8,6 +8,7 @@ class Tag(str, Enum):
     PROCESSED = "PRC"
     QA_APPROVED = "QA01"
     QA_PENDING = "QA02"
+    QA_FAILED = "QA03"
 
 
 SERVICE_INFO = {"version": __version__, "name": "OpenReferee JACoW"}
@@ -35,6 +36,7 @@ DEFAULT_TAGS = {
     Tag.PROCESSED: {"title": "Processed", "color": "brown", "system": True},
     Tag.QA_APPROVED: {"title": "QA Approved", "color": "green", "system": True},
     Tag.QA_PENDING: {"title": "QA Pending", "color": "yellow", "system": True},
+    Tag.QA_FAILED: {"title": "QA Failed", "color": "red", "system": True},
 }
 DEFAULT_EDITABLES = {"paper", "poster"}
 DEFAULT_FILE_TYPES = {

--- a/openreferee_server/operations.py
+++ b/openreferee_server/operations.py
@@ -210,13 +210,10 @@ def process_custom_action(event, revision, action, user, endpoints):
             "comments": [{"internal": True, "text": "This revision has passed QA."}],
         }
     elif action == "fail-qa":
-        response = session.post(
-            endpoints["revisions"]["reset"],
-        )
-        response.raise_for_status()
         return {
-            "tags": revision_tags,
+            "tags": revision_tags + [available_tags[Tag.QA_FAILED]["id"]],
             "publish": False,
             "comments": [{"internal": True, "text": "This revision has failed QA."}],
+            "reset": True,
         }
     return {}

--- a/openreferee_server/schemas.py
+++ b/openreferee_server/schemas.py
@@ -25,7 +25,6 @@ class EditableEndpointsSchema(Schema):
             "details": fields.String(required=True),
             "replace": fields.String(required=True),
             "undo": fields.String(required=True),
-            "reset": fields.String(required=True),
         }
     )
     file_upload = fields.String(required=True)
@@ -216,3 +215,4 @@ class ServiceActionResultSchema(Schema):
     comments = fields.List(fields.Nested(CommentSchema))
     tags = fields.List(fields.Int())
     redirect = fields.String(missing=None)
+    reset = fields.Boolean(missing=False)


### PR DESCRIPTION
- Use the new "reset" flag on the fail QA response, instead of using the reset endpoint
- Add a "Fail QA" tag

Note: on deployment the service must be disconnected and reconnected to introduce the new tag