### PR TITLE
Remove thread implementation

### DIFF
--- a/openreferee_server/notify.py
+++ b/openreferee_server/notify.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import threading
 
 from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
 
@@ -21,7 +20,7 @@ class NotifyService:
 
     def send(self, payload):
         try:
-            self.session.post(self.url, json={"payload": payload})
+            self.session.post(self.url, json={"payload": payload}, timeout=10)
         except HTTPError as e:
             self.log_error("Invalid response from notify: %s", str(e))
         except ConnectionError as e:
@@ -38,7 +37,7 @@ class NotifyService:
         if self.session is None:
             self.session = setup_requests_session(self.token)
 
-        threading.Thread(target=self.send, args=(payload,)).start()
+        self.send(payload)
 
 
 def notify_init(app):


### PR DESCRIPTION
I have been investigating why I am not getting notifications reliably.

I believe using threading might be causing the issue. I believe the child thread may be terminating before the request completes, due to the parent thread completing.

@ThiefMaster I believe you recommended against using threading in my original PR. My reason at the time for introducing it was to prevent any delays sending the notification would introduce. But even with good intentions my implementation wasn't going to work.

I have removed it from using a thread, and I introduced a 10 second timeout on the request. Hopefully this will fix the issue.