### PR TITLE
Remove unneeded request and user objects

### DIFF
--- a/openreferee_server/notify.py
+++ b/openreferee_server/notify.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import threading
 
 from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
 
@@ -38,7 +37,7 @@ class NotifyService:
         if self.session is None:
             self.session = setup_requests_session(self.token)
 
-        threading.Thread(target=self.send, args=(payload,)).start()
+        self.send(payload)
 
 
 def notify_init(app):

--- a/openreferee_server/server.py
+++ b/openreferee_server/server.py
@@ -257,8 +257,6 @@ def create_editable(
         "contrib_id": contrib_id,
         "action": "create",
         "editable_type": editable_type,
-        "user": user,
-        "request": request.json
     })
 
     replace_revision_files()
@@ -307,8 +305,6 @@ def review_editable(
         "revision_id": revision_id,
         "action": action,
         "editable_type": editable_type,
-        "user": user,
-        "request": request.json
     })
 
     if action in {'accept', 'update_accept'}:


### PR DESCRIPTION
I would like to remove the user / request object data in the create notification payload. 

This is for two reasons.

[1] I am worried it is causing a serialisation issue when converting to a json payload
[2] I do not need this information